### PR TITLE
Require guzzle/http only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "guzzle/http": "3.*"
     },
     "require-dev": {
+        "guzzle/guzzle": "3.*",
         "symfony/framework-bundle": ">=2.1.0,<2.3-dev"
     },
     "autoload": {


### PR DESCRIPTION
There's no need to require the whole `guzzle/guzzle` package, [`guzzle/http`](https://github.com/guzzle/http) should be sufficient.
