### PR TITLE
Update panel view to link to packagist package

### DIFF
--- a/Resources/views/Collector/versioneye.html.twig
+++ b/Resources/views/Collector/versioneye.html.twig
@@ -60,7 +60,7 @@
             </tr>
             {% for i, dep in collector.data.dependencies %}
                 <tr>
-                    <td><code>{{ dep.name }}</code></td>
+                    <td><code><a href='https://packagist.org/packages/{{ dep.name }}'>{{ dep.name }}</a></code></td>
                     <td style="background-color:{{ dep.outdated == true ? '#f66;' : '#0e0' }};"><code>{{ dep.version_requested }}</code></td>
                     <td style="background-color:{{ dep.outdated == true ? '#f66;' : '#0e0' }};"><code>{{ dep.version_current }}</code></td>
                 </tr>


### PR DESCRIPTION
With this change you can directly go to packagist to look at the new versions and figure out if you need to update instead of needing to google search for the package. 
This might fail for packages not on packagist though. 
